### PR TITLE
convert roman numerals to arabic

### DIFF
--- a/roman_numeral_converter.rb
+++ b/roman_numeral_converter.rb
@@ -1,0 +1,33 @@
+class RomanToArabicConverter
+
+  ROMAN_TO_ARABIC_MAP = {
+    "M"=>1000,
+    "CM"=>900,
+    "D"=>500,
+    "CD"=>400,
+    "C"=>100,
+    "XC"=>90,
+    "L"=>50,
+    "XL"=>40,
+    "X"=>10,
+    "IX"=>9,
+    "V"=>5,
+    "IV"=>4,
+    "I"=>1
+  }
+
+  def convert(roman)
+    raise "input must be a string" if !roman.is_a?(String)
+    keys = ROMAN_TO_ARABIC_MAP.keys
+    result = 0
+    keys.each do |i|
+      while roman.start_with?(i)
+        result += ROMAN_TO_ARABIC_MAP[i]
+        roman = roman.slice(i.length, (roman.length - i.length))
+      end
+    end
+    raise "invalid roman input" if !roman.empty?
+    result
+  end
+
+end

--- a/roman_numeral_converter.rb
+++ b/roman_numeral_converter.rb
@@ -1,4 +1,4 @@
-class RomanToArabicConverter
+class RomanArabicConverter
 
   ROMAN_TO_ARABIC_MAP = {
     "M"=>1000,
@@ -16,18 +16,26 @@ class RomanToArabicConverter
     "I"=>1
   }
 
-  def convert(roman)
+  def convert_to_arabic(roman)
     raise "input must be a string" if !roman.is_a?(String)
-    keys = ROMAN_TO_ARABIC_MAP.keys
     result = 0
-    keys.each do |i|
-      while roman.start_with?(i)
-        result += ROMAN_TO_ARABIC_MAP[i]
-        roman = roman.slice(i.length, (roman.length - i.length))
+    ROMAN_TO_ARABIC_MAP.each do |numeral, value|
+      while roman.start_with?(numeral)
+        result += value
+        roman.slice!(0..numeral.length-1)
       end
     end
     raise "invalid roman input" if !roman.empty?
     result
   end
 
+  def convert_to_roman(arabic)
+    raise "input must be a positive integer" if (!arabic.is_a?(Integer) || arabic < 1 )
+    result = ""
+    ROMAN_TO_ARABIC_MAP.each do |numeral, value|
+      result << numeral * (arabic / value)
+      arabic = arabic % value
+    end
+    result
+  end
 end

--- a/roman_numeral_converter_spec.rb
+++ b/roman_numeral_converter_spec.rb
@@ -2,37 +2,69 @@ require_relative "./roman_numeral_converter.rb"
 
 describe "Roman Numeral Converter" do
   context "roman numeral to arabic conversion" do
-    before { @converter = RomanToArabicConverter.new }
+    before { @converter = RomanArabicConverter.new }
 
     context "roman numeral is valid" do
       context "roman numeral is one character" do
-        specify { expect(@converter.convert("I")).to eq(1) }
-        specify { expect(@converter.convert("V")).to eq(5) }
-        specify { expect(@converter.convert("X")).to eq(10) }
-        specify { expect(@converter.convert("L")).to eq(50) }
-        specify { expect(@converter.convert("C")).to eq(100) }
-        specify { expect(@converter.convert("D")).to eq(500) }
-        specify { expect(@converter.convert("M")).to eq(1000) }
+        specify { expect(@converter.convert_to_arabic("I")).to eq(1) }
+        specify { expect(@converter.convert_to_arabic("V")).to eq(5) }
+        specify { expect(@converter.convert_to_arabic("X")).to eq(10) }
+        specify { expect(@converter.convert_to_arabic("L")).to eq(50) }
+        specify { expect(@converter.convert_to_arabic("C")).to eq(100) }
+        specify { expect(@converter.convert_to_arabic("D")).to eq(500) }
+        specify { expect(@converter.convert_to_arabic("M")).to eq(1000) }
       end
       context "addition between roman numerals" do
-        specify { expect(@converter.convert("CXI")).to eq(111) }
-        specify { expect(@converter.convert("CCC")).to eq(300) }
-        specify { expect(@converter.convert("DIX")).to eq(509) }
+        specify { expect(@converter.convert_to_arabic("CXI")).to eq(111) }
+        specify { expect(@converter.convert_to_arabic("CCC")).to eq(300) }
+        specify { expect(@converter.convert_to_arabic("DIX")).to eq(509) }
       end
-      context "roman numerals that are two character long" do
-        specify { expect(@converter.convert("IV")).to eq(4) }
-        specify { expect(@converter.convert("IX")).to eq(9) }
-        specify { expect(@converter.convert("XL")).to eq(40) }
-        specify { expect(@converter.convert("XC")).to eq(90) }
-        specify { expect(@converter.convert("CD")).to eq(400) }
-        specify { expect(@converter.convert("CM")).to eq(900) }
+      context "roman numerals that are two characters long" do
+        specify { expect(@converter.convert_to_arabic("IV")).to eq(4) }
+        specify { expect(@converter.convert_to_arabic("IX")).to eq(9) }
+        specify { expect(@converter.convert_to_arabic("XL")).to eq(40) }
+        specify { expect(@converter.convert_to_arabic("XC")).to eq(90) }
+        specify { expect(@converter.convert_to_arabic("CD")).to eq(400) }
+        specify { expect(@converter.convert_to_arabic("CM")).to eq(900) }
+      end
+      context "roman numerals that are complex" do
+        specify { expect(@converter.convert_to_arabic("MCMXLIV")).to eq(1944)}
+        specify { expect(@converter.convert_to_arabic("MMMMCCCXXI")).to eq(4321)}
       end
     end
 
     context "roman numeral is invalid" do
-      specify { expect{ @converter.convert(123) }.to raise_error("input must be a string") }
-      specify { expect{ @converter.convert("XIQ") }.to raise_error("invalid roman input") }
-      specify { expect{ @converter.convert("BOGUS") }.to raise_error("invalid roman input") }
+      specify { expect{ @converter.convert_to_arabic(123) }.to raise_error("input must be a string") }
+      specify { expect{ @converter.convert_to_arabic("XIQ") }.to raise_error("invalid roman input") }
+      specify { expect{ @converter.convert_to_arabic("BOGUS") }.to raise_error("invalid roman input") }
+    end
+  end
+
+  context "arabic to roman numeral conversion" do
+    before { @converter = RomanArabicConverter.new }
+
+    context "arabic numeral is valid" do
+      context "arabic numbers that convert to single roman numeral" do
+        specify { expect(@converter.convert_to_roman(1)).to eq("I") }
+        specify { expect(@converter.convert_to_roman(5)).to eq("V") }
+        specify { expect(@converter.convert_to_roman(10)).to eq("X") }
+        specify { expect(@converter.convert_to_roman(50)).to eq("L") }
+        specify { expect(@converter.convert_to_roman(100)).to eq("C") }
+        specify { expect(@converter.convert_to_roman(500)).to eq("D") }
+        specify { expect(@converter.convert_to_roman(1000)).to eq("M") }
+      end
+      context "arabic number converts to multiple roman numerals" do
+        specify { expect(@converter.convert_to_roman(1944)).to eq("MCMXLIV")}
+        specify { expect(@converter.convert_to_roman(4321)).to eq("MMMMCCCXXI")}
+      end
+    end
+
+    context "arabic numeral is invalid" do
+      specify { expect{ @converter.convert_to_roman('ABC') }.to raise_error("input must be a positive integer") }
+      specify { expect{ @converter.convert_to_roman(2.4) }.to raise_error("input must be a positive integer") }
+      specify { expect{ @converter.convert_to_roman(-10) }.to raise_error("input must be a positive integer") }
+      specify { expect{ @converter.convert_to_roman(0) }.to raise_error("input must be a positive integer") }
     end
   end
 end
+

--- a/roman_numeral_converter_spec.rb
+++ b/roman_numeral_converter_spec.rb
@@ -1,0 +1,38 @@
+require_relative "./roman_numeral_converter.rb"
+
+describe "Roman Numeral Converter" do
+  context "roman numeral to arabic conversion" do
+    before { @converter = RomanToArabicConverter.new }
+
+    context "roman numeral is valid" do
+      context "roman numeral is one character" do
+        specify { expect(@converter.convert("I")).to eq(1) }
+        specify { expect(@converter.convert("V")).to eq(5) }
+        specify { expect(@converter.convert("X")).to eq(10) }
+        specify { expect(@converter.convert("L")).to eq(50) }
+        specify { expect(@converter.convert("C")).to eq(100) }
+        specify { expect(@converter.convert("D")).to eq(500) }
+        specify { expect(@converter.convert("M")).to eq(1000) }
+      end
+      context "addition between roman numerals" do
+        specify { expect(@converter.convert("CXI")).to eq(111) }
+        specify { expect(@converter.convert("CCC")).to eq(300) }
+        specify { expect(@converter.convert("DIX")).to eq(509) }
+      end
+      context "roman numerals that are two character long" do
+        specify { expect(@converter.convert("IV")).to eq(4) }
+        specify { expect(@converter.convert("IX")).to eq(9) }
+        specify { expect(@converter.convert("XL")).to eq(40) }
+        specify { expect(@converter.convert("XC")).to eq(90) }
+        specify { expect(@converter.convert("CD")).to eq(400) }
+        specify { expect(@converter.convert("CM")).to eq(900) }
+      end
+    end
+
+    context "roman numeral is invalid" do
+      specify { expect{ @converter.convert(123) }.to raise_error("input must be a string") }
+      specify { expect{ @converter.convert("XIQ") }.to raise_error("invalid roman input") }
+      specify { expect{ @converter.convert("BOGUS") }.to raise_error("invalid roman input") }
+    end
+  end
+end


### PR DESCRIPTION
Roman-Arabic converter.
Converts Roman numerals to Arabic, and Arabic to Roman.

Using a hash to map roman numerals to corresponding arabic numbers.
